### PR TITLE
Switch model to llava-v1.6-mistral-7b

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Corepack is a nodejs module that enables to use other package managers (pnpm, ya
 This is a temporary development integration. llamafile is now integrated into the GitHub repo but manually downloading the model is still required to run the app. This shouldn't interfere with the build process even those builds won't actually work without the model.
 
 ```bash
-# Download the Dolphin Mistral model
+# Download the llava-1.6-mistral-7b model
 mkdir -p src-tauri/models
-curl -L -o src-tauri/models/dolphin-2.6-mistral-7b.Q4_K_M.gguf https://huggingface.co/TheBloke/dolphin-2.6-mistral-7B-GGUF/resolve/main/dolphin-2.6-mistral-7b.Q4_K_M.gguf
+curl -L -o src-tauri/models/llava-v1.6-mistral-7b.Q5_K_M.gguf https://huggingface.co/cjpais/llava-1.6-mistral-7b-gguf/resolve/main/llava-v1.6-mistral-7b.Q5_K_M.gguf?download=true
 ```
 
 ## Start the app
@@ -78,4 +78,6 @@ See more examples in commits history.
 ## Recommended IDE Setup
 
 - [VS Code](https://code.visualstudio.com/) + [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode) + [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
+
+```
 

--- a/src/llamafile.ts
+++ b/src/llamafile.ts
@@ -5,7 +5,7 @@ export default class Llamafile {
 
   private process: Child | null;
 
-  constructor(model = 'dolphin-2.6-mistral-7b.Q4_K_M.gguf') {
+  constructor(model = 'llava-v1.6-mistral-7b.Q5_K_M.gguf') {
     this.command = Command.sidecar('bin/llamafile', [
       '-m',
       `models/${model}`,


### PR DESCRIPTION
Switch our default model to [llava-v1.6-mistral-7b](https://huggingface.co/cjpais/llava-1.6-mistral-7b-gguf). This model supports text and image input. You will need to download the new model in dev:

```
curl -L -o src-tauri/models/llava-v1.6-mistral-7b.Q5_K_M.gguf https://huggingface.co/cjpais/llava-1.6-mistral-7b-gguf/resolve/main/llava-v1.6-mistral-7b.Q5_K_M.gguf?download=true
```

**More info on Llava 1.6**
https://llava-vl.github.io/blog/2024-01-30-llava-next/