### PR TITLE
Robust downloads

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5134,7 +5134,6 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-upload"
 version = "0.0.0"
-source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v1#5e3900e682e13f3759b439116ae2f77a6d389ca2"
 dependencies = [
  "futures-util",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,7 +13,6 @@ tauri-build = { version = "1.5", features = [] }
 tauri = { version = "1.5", features = ["api-all", "updater", "test"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tauri-plugin-upload = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 tauri-plugin-window-state = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 log = { version = "^0.4", features = ["max_level_info"] }
 tauri-plugin-log = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
@@ -26,6 +25,9 @@ thiserror = "1"
 
 [profile.dev.package.nebula]
 opt-level = 3
+
+[dependencies.tauri-plugin-upload]
+path = './tauri-plugin-upload'
 
 [dependencies.tauri-plugin-sql]
 path = "./tauri-plugin-sql"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -13,7 +13,7 @@ where
     let app_data_dir = app.handle().path_resolver().app_data_dir();
     info!(
         "App data dir: \x1b[34m{}\x1b[0m",
-        app_data_dir.unwrap().to_str().unwrap()
+        app_data_dir.unwrap().to_str().unwrap().replace(" ", "\\ ")
     );
     Ok(())
 }

--- a/src-tauri/tauri-plugin-upload/cargo.toml
+++ b/src-tauri/tauri-plugin-upload/cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "tauri-plugin-upload"
+version = "0.0.0"
+description = "Upload files from disk to a remote server over HTTP."
+edition = "2021"
+
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+log = "0.4"
+tauri = "1"
+thiserror = "1"
+tokio = { version = "1", features = ["fs"] }
+tokio-util = { version = "0.7", features = ["codec"] }
+reqwest = { version = "0.12", features = ["json", "stream"] }
+futures-util = "0.3"
+read-progress-stream = "1.0.0"

--- a/src-tauri/tauri-plugin-upload/src/lib.rs
+++ b/src-tauri/tauri-plugin-upload/src/lib.rs
@@ -1,0 +1,159 @@
+// Copyright 2021 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+use futures_util::TryStreamExt;
+use log::info;
+use serde::{ser::Serializer, Serialize};
+use tauri::{
+    command,
+    plugin::{Builder as PluginBuilder, TauriPlugin},
+    Runtime, Window,
+};
+use tokio::{
+    fs::File,
+    io::{AsyncWriteExt, BufWriter},
+};
+use tokio_util::codec::{BytesCodec, FramedRead};
+
+use read_progress_stream::ReadProgressStream;
+
+use std::{collections::HashMap, sync::Mutex};
+
+type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Request(#[from] reqwest::Error),
+    #[error("{0}")]
+    ContentLength(String),
+    #[error("request failed with status code {0}: {1}")]
+    HttpErrorCode(u16, String),
+}
+
+impl Serialize for Error {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.to_string().as_ref())
+    }
+}
+
+#[derive(Clone, Serialize)]
+struct ProgressPayload {
+    id: u32,
+    progress: u64,
+    total: u64,
+}
+
+#[command]
+async fn download<R: Runtime>(
+    window: Window<R>,
+    id: u32,
+    url: &str,
+    file_path: &str,
+    headers: HashMap<String, String>,
+) -> Result<u32> {
+    let client = reqwest::Client::new();
+
+    let mut progress: u64 = 0;
+
+    let mut request = client.get(url);
+    // Loop trought the headers keys and values
+    // and add them to the request object.
+    for (key, value) in headers {
+        request = request.header(&key, value);
+    }
+
+    let response = request.send().await?;
+    let total = response.content_length().unwrap_or(0);
+
+    let mut file = BufWriter::new(File::create(file_path).await?);
+    let mut stream = response.bytes_stream();
+
+    while let Some(chunk) = stream.try_next().await? {
+        file.write_all(&chunk).await?;
+
+        progress = chunk.len() as u64;
+
+        let emit_result = window.emit(
+            "download://progress",
+            ProgressPayload {
+                id,
+                progress,
+                total,
+            },
+        );
+
+        if emit_result.is_err() {
+            info!("Failed to emit download progress event");
+        }
+    }
+    file.flush().await?;
+
+    Ok(id)
+}
+
+#[command]
+async fn upload<R: Runtime>(
+    window: Window<R>,
+    id: u32,
+    url: &str,
+    file_path: &str,
+    headers: HashMap<String, String>,
+) -> Result<String> {
+    // Read the file
+    let file = File::open(file_path).await?;
+    let file_len = file.metadata().await.unwrap().len();
+
+    // Create the request and attach the file to the body
+    let client = reqwest::Client::new();
+    let mut request = client
+        .post(url)
+        .header(reqwest::header::CONTENT_LENGTH, file_len)
+        .body(file_to_body(id, window, file));
+
+    // Loop trought the headers keys and values
+    // and add them to the request object.
+    for (key, value) in headers {
+        request = request.header(&key, value);
+    }
+
+    let response = request.send().await?;
+    if response.status().is_success() {
+        response.text().await.map_err(Into::into)
+    } else {
+        Err(Error::HttpErrorCode(
+            response.status().as_u16(),
+            response.text().await.unwrap_or_default(),
+        ))
+    }
+}
+
+fn file_to_body<R: Runtime>(id: u32, window: Window<R>, file: File) -> reqwest::Body {
+    let stream = FramedRead::new(file, BytesCodec::new()).map_ok(|r| r.freeze());
+    let window = Mutex::new(window);
+    reqwest::Body::wrap_stream(ReadProgressStream::new(
+        stream,
+        Box::new(move |progress, total| {
+            let _ = window.lock().unwrap().emit(
+                "upload://progress",
+                ProgressPayload {
+                    id,
+                    progress,
+                    total,
+                },
+            );
+        }),
+    ))
+}
+
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+    PluginBuilder::new("upload")
+        .invoke_handler(tauri::generate_handler![download, upload])
+        .build()
+}

--- a/src-tauri/tauri-plugin-upload/src/lib.rs
+++ b/src-tauri/tauri-plugin-upload/src/lib.rs
@@ -60,7 +60,7 @@ async fn download<R: Runtime>(
 ) -> Result<u32> {
     let client = reqwest::Client::new();
 
-    let mut progress: u64 = 0;
+    let mut progress = 0.;
     let mut last_percent = 0;
 
     let mut request = client.get(url);
@@ -79,14 +79,14 @@ async fn download<R: Runtime>(
     while let Some(chunk) = stream.try_next().await? {
         file.write_all(&chunk).await?;
 
-        progress += chunk.len() as u64;
-        if progress / total * 100 > last_percent {
-            last_percent = progress / total * 100;
+        progress += chunk.len() as f64;
+        if (progress / total as f64 * 100.0) as i32 > last_percent {
+            last_percent = (progress / total as f64 * 100.0) as i32;
             let _ = window.emit(
                 "download://progress",
                 ProgressPayload {
                     id,
-                    progress,
+                    progress: progress as u64,
                     total,
                 },
             );

--- a/src/widgets/welcome-screen/ui/ModelDownload/ModelDownload.tsx
+++ b/src/widgets/welcome-screen/ui/ModelDownload/ModelDownload.tsx
@@ -24,12 +24,9 @@ interface Props {
 }
 
 const handleDownload = (modelName: AIModelName) => {
-  let progress = 0;
   downloadModel(modelName, (downloaded, total) => {
-    progress += downloaded;
-
     setTotal(total);
-    setProgress(progress);
+    setProgress(downloaded);
   });
 };
 


### PR DESCRIPTION
Limits the number of download progress events sent to the front-end since it seems it silently crashes the app when too many are sent leading to corrupted downloads.