### PR TITLE
Add verify hash param to download command

### DIFF
--- a/src-tauri/src/fs/file_system.rs
+++ b/src-tauri/src/fs/file_system.rs
@@ -26,13 +26,13 @@ impl Serialize for Error {
 type Result<T> = std::result::Result<T, Error>;
 
 #[command]
-fn get_byte_size(path: String) -> Result<u64> {
+fn get_byte_size(path: &str) -> Result<u64> {
     let metadata = fs::metadata(path)?;
     Ok(metadata.len())
 }
 
 #[command]
-async fn get_file_sha_256(path: String) -> Result<String> {
+pub async fn get_file_sha_256(path: &str) -> Result<String> {
     let mut hasher = Sha256::new();
     let mut file = fs::File::open(path)?;
 
@@ -79,14 +79,14 @@ mod tests {
             .join("smallFile.txt")
             .to_string_lossy()
             .to_string();
-        let result = super::get_byte_size(model_path).unwrap();
+        let result = super::get_byte_size(&model_path).unwrap();
         assert_eq!(result, 50);
     }
 
     #[test]
     fn test_get_byte_size_invalid_path() {
         let model_path = "invalid_path".to_string();
-        let result = super::get_byte_size(model_path);
+        let result = super::get_byte_size(&model_path);
         assert!(result.is_err());
     }
 
@@ -98,7 +98,7 @@ mod tests {
             .join("smallFile.txt")
             .to_string_lossy()
             .to_string();
-        let result = super::get_file_sha_256(model_path).await.unwrap();
+        let result = super::get_file_sha_256(&model_path).await.unwrap();
         assert_eq!(
             result,
             "7c4df6533de1d94d4d862f3472255e92e2292180b027819e60ebb51fcdc50c4e"
@@ -108,7 +108,7 @@ mod tests {
     #[tokio::test]
     async fn test_sample_model_sha_256_invalid_path() {
         let model_path = "invalid_path".to_string();
-        let result = super::get_file_sha_256(model_path).await;
+        let result = super::get_file_sha_256(&model_path).await;
         assert!(result.is_err());
     }
 }

--- a/src-tauri/src/fs/mod.rs
+++ b/src-tauri/src/fs/mod.rs
@@ -1,3 +1,3 @@
 mod file_system;
 
-pub use file_system::init_plugin;
+pub use file_system::*;

--- a/src/shared/lib/file-transfer.ts
+++ b/src/shared/lib/file-transfer.ts
@@ -1,5 +1,6 @@
 import { invoke } from '@tauri-apps/api/tauri';
 import { appWindow } from '@tauri-apps/api/window';
+import { error } from 'tauri-plugin-log';
 
 interface ProgressPayload {
   id: number;
@@ -32,7 +33,7 @@ export async function interruptFileTransfer(id: number): Promise<void> {
   try {
     await invoke('plugin:file_transfer|interrupt', { id });
   } catch (e) {
-    console.error(e);
+    error(`${e}`);
   }
 }
 
@@ -73,18 +74,22 @@ export async function upload({
 ///
 /// Note that `filePath` currently must include the file name.
 /// Furthermore the progress events will report a total length of 0 if the server did not sent a `Content-Length` header or if the file is compressed.
+/// VerifyHash will automatically try to extract the x-linked-etag header and compare it to the sha256 of the downloaded file.
+/// If the hashes do not match, an error will be thrown but the file will still be on disk. Same if the header is not present.
 export async function download({
   id = getRandomInt(),
   url,
   path,
   progressHandler,
   headers,
+  verifyHash = false,
 }: {
   id?: number;
   url: string;
   path: string;
   progressHandler?: ProgressHandler;
   headers?: Map<string, string>;
+  verifyHash?: boolean;
 }): Promise<void> {
   if (progressHandler != null) {
     handlers.set(id, progressHandler);
@@ -97,5 +102,6 @@ export async function download({
     url,
     path,
     headers: headers ?? {},
+    verify_hash: verifyHash,
   });
 }

--- a/src/shared/lib/file-transfer.ts
+++ b/src/shared/lib/file-transfer.ts
@@ -74,8 +74,9 @@ export async function upload({
 ///
 /// Note that `filePath` currently must include the file name.
 /// Furthermore the progress events will report a total length of 0 if the server did not sent a `Content-Length` header or if the file is compressed.
-/// VerifyHash will automatically try to extract the x-linked-etag header and compare it to the sha256 of the downloaded file.
+/// `verifyHash` will automatically try to extract the x-linked-etag header and compare it to the sha256 of the downloaded file.
 /// If the hashes do not match, an error will be thrown but the file will still be on disk. Same if the header is not present.
+/// The `x-linked-etag` as a hash is NOT standard practice and might only work with hugging face responses.
 export async function download({
   id = getRandomInt(),
   url,


### PR DESCRIPTION
@demetrxx take a look at the updated comments in the doc. You can now directly request for file hash verification after download is finished. No event is emitted for now. Let me know if you have questions.

Also this will probably only work with hugging face, as they put the file sha in the ETAG header, which might not be true for all services, so be careful if using somewhere else.